### PR TITLE
feat: Add reading progress bar to post pages #54

### DIFF
--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -1,31 +1,38 @@
 import { posts } from "../../../data/posts";
 import Sidebar from "../../../components/Sidebar";
-import Head from "next/head";
 import Image from "next/image";
 import Comments from "../../../components/Comments";
+import ReadingProgressBar from "../../../components/ReadingProgressBar";
+
 type BlogDetailProps = {
   params: {
     id: string;
   };
 };
 
+// Optional but recommended: Add metadata for SEO
+export async function generateMetadata({ params }: BlogDetailProps) {
+  const { id } = params; // 1. Destructure id from params
+  const post = posts.find((p) => p.id.toString() === id); // 2. Use the new id variable
+
+  if (!post) return { title: "Post not found" };
+
+  return {
+    title: `${post.title} - TechBlog`,
+    description: post.content.replace(/<[^>]+>/g, "").slice(0, 150),
+  };
+}
 
 export default async function BlogDetail({ params }: BlogDetailProps) {
-  const postId = params.id;
-
-  const post = posts.find((p) => p.id.toString() === postId);
+  const { id } = params; // 3. Destructure id from params here as well
+  const post = posts.find((p) => p.id.toString() === id); // 4. Use the new id variable
 
   if (!post) return <p>Post not found</p>;
 
   return (
     <>
-      <Head>
-        <title>{post.title} - TechBlog</title>
-        <meta
-          name="description"
-          content={post.content.replace(/<[^>]+>/g, "").slice(0, 150)}
-        />
-      </Head>
+      <ReadingProgressBar />
+
       <section className="blog-detail">
         <article>
           <span className="category detail-category">#{post.category}</span>

--- a/src/components/ReadingProgressBar.tsx
+++ b/src/components/ReadingProgressBar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+
+export default function ReadingProgressBar() {
+  const [width, setWidth] = useState(0);
+
+  // Scroll event handler
+  const handleScroll = () => {
+    // Get the total scrollable height of the page
+    const totalHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    // Calculate the scrolled percentage
+    const scrollPercentage = (window.scrollY / totalHeight) * 100;
+    setWidth(scrollPercentage);
+  };
+
+  useEffect(() => {
+    // Add the event listener when the component mounts
+    window.addEventListener('scroll', handleScroll);
+
+    // Clean up the event listener when the component unmounts
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []); // Empty dependency array means this effect runs only once
+
+  return (
+    <div className="progress-bar-container">
+      <div className="progress-bar" style={{ width: `${width}%` }}></div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -544,6 +544,23 @@ a:hover {
     color: #ffeb3b;
 }
 
+.progress-bar-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 5px; /* Adjust height as needed */
+  background-color: #e0e0e0; /* The background of the bar */
+  z-index: 9999; /* Ensures it's on top of other content */
+}
+
+.progress-bar {
+  height: 100%;
+  background-color: #0070f3; /* The color of the progress indicator */
+  transition: width 0.1s linear; /* Smooth transition for the width change */
+}
+
+
 /* Responsive adjustments for headers and text */
 @media (max-width: 600px) {
     .post-title {
@@ -554,3 +571,4 @@ a:hover {
         font-size: 1.4rem;
     }
 }
+


### PR DESCRIPTION



Closes #54

## Description

This pull request introduces a reading progress bar that appears at the top of the viewport on individual blog post pages. This feature enhances the user experience by providing visual feedback on reading progress, indicating how much of an article the user has scrolled through.

The progress bar is only visible on post detail pages and updates smoothly in real time as the user scrolls.

## Changes Made

* **New Component (`ReadingProgressBar.tsx`):**
    * Created a new reusable client component (`"use client"`) to manage the progress bar's state and logic.
    * Uses the `useEffect` hook to safely add and clean up a `scroll` event listener on the window.
    * Calculates the scroll percentage and updates the bar's width using `useState`.

* **Styling:**
    * Added CSS styles to `styles/globals.css` for the progress bar container and the progress indicator itself.
    * The bar is styled with `position: fixed` and a high `z-index` to ensure it remains visible at the top of the page during scrolling.

* **Integration:**
    * Imported and placed the `<ReadingProgressBar />` component into the main post detail page (`app/post/[id]/page.tsx`).

* **Bug Fixes & Refactoring:**
    * Resolved a runtime error in `page.tsx` by correctly destructuring the `id` from the `params` object, aligning with recent Next.js App Router requirements.
    * Updated the metadata handling from the deprecated `<Head>` component to the recommended `generateMetadata` function for the App Router.

## How to Test

1.  Check out this branch (`feature/reading-progress-bar`).
2.  Run `npm install` to ensure all dependencies are up to date.
3.  Start the development server with `npm run dev`.
4.  Navigate to the homepage and click on any blog post to open its detail page.
5.  **Verify:** A thin progress bar appears at the very top of the screen.
6.  Scroll down the page.
7.  **Verify:** The progress bar fills from left to right as you scroll, reaching 100% width when you reach the bottom.
8.  Navigate to non-post pages (like the homepage or a category page).
9.  **Verify:** The progress bar is not present on these pages.

## Screenshot

<img width="1230" height="979" alt="Screenshot 2025-10-04 202414" src="https://github.com/user-attachments/assets/c4ec922e-d51e-4293-8af6-ab7a197092b3" />
