### PR TITLE
Implement fallback mechanism for visitor count in case of API failure

### DIFF
--- a/src/components/VisitorCount.tsx
+++ b/src/components/VisitorCount.tsx
@@ -18,6 +18,14 @@ export default function VisitorCount({ simple = false }: { simple?: boolean }) {
         trackVisit();
     }, []);
 
+    const randomInRange = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+    const applyFallback = () => {
+        setStats({
+            todayVisitors: randomInRange(70, 90),
+            totalVisitors: randomInRange(100, 200)
+        });
+    };
+
     const trackVisit = async () => {
         try {
             const response = await fetch('/api/visitor', {
@@ -34,9 +42,12 @@ export default function VisitorCount({ simple = false }: { simple?: boolean }) {
                     todayVisitors: data.todayVisitors,
                     totalVisitors: data.totalVisitors
                 });
+            } else {
+                applyFallback();
             }
         } catch (error) {
             console.error('Error tracking visit:', error);
+            applyFallback();
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
## Description
Implemented a temporary frontend fallback for the Visitor page when the backend cannot persist data on Vercel. If the `/api/visitor` POST fails or returns `success: false`, the UI now displays randomized counts within the specified ranges (today: 70–90, total: 100–200). When the API succeeds, real counts are shown as before.  
Fixes #79

- Edited: `src/components/VisitorCount.tsx`
- No linter issues introduced

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Checklist
- [x] My code follows the repository style guidelines
- [x] I have performed a self-review of my changes
- [ ] I have added necessary documentation (if applicable)

## Additional Notes
- This is a temporary measure due to Vercel’s read-only filesystem. Replace/remove once a durable backend visitor API is available.
